### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/actions-demo.yml
+++ b/.github/workflows/actions-demo.yml
@@ -75,7 +75,7 @@ jobs:
           id: get_version
           run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV       
         - name: Create a Release
-          uses: elgohr/Github-Release-Action@main
+          uses: elgohr/Github-Release-Action@v4
           env:
             GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore